### PR TITLE
Add workout log: 2026-01-13-1768275853_workout.json

### DIFF
--- a/fitness/workout_logs/2026-01-13-1768275853_workout.json
+++ b/fitness/workout_logs/2026-01-13-1768275853_workout.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-01-13-1768275853",
+  "session_name": "squat_horizontal_pushpull",
+  "bodyweight_lb": 155,
+  "exercises": [
+    {
+      "exercise_name": "barbell_squat",
+      "sets": [
+        {
+          "reps": 8,
+          "lb": 130
+        },
+        {
+          "reps": 8,
+          "lb": 130
+        },
+        {
+          "reps": 8,
+          "lb": 130
+        }
+      ]
+    },
+    {
+      "exercise_name": "barbell_bench_press",
+      "sets": [
+        {
+          "reps": 8,
+          "lb": 110
+        },
+        {
+          "reps": 8,
+          "lb": 110
+        },
+        {
+          "reps": 5,
+          "lb": 110
+        }
+      ]
+    },
+    {
+      "exercise_name": "barbell_bent_over_row",
+      "sets": [
+        {
+          "reps": 8,
+          "lb": 95
+        },
+        {
+          "reps": 8,
+          "lb": 95
+        },
+        {
+          "reps": 8,
+          "lb": 95
+        }
+      ]
+    },
+    {
+      "exercise_name": "dumbell_lateral_raise",
+      "sets": [
+        {
+          "reps": 12,
+          "lb": 12
+        },
+        {
+          "reps": 12,
+          "lb": 12
+        }
+      ]
+    },
+    {
+      "exercise_name": "dumbell_biceps_curl",
+      "sets": [
+        {
+          "reps": 12,
+          "lb": 25
+        },
+        {
+          "reps": 12,
+          "lb": 25
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Notes for each exercise
* Notes in general
* Add cycling and stretching to all sessions programmatically
* Put numbers on my session names or use routines and auto-number it
* For each subsequent set, update the weight to whatever was entered in the previous set for the same exercise
* Keep the timer on even if I'm not focused on that page anymore, eg when I'm on mobile and I switch apps
* Plate calculator
* Make the checkbox bigger so it's easier to click on
* Auto weight updater for the next time that exercise is done, including "didn't hit your reps" limiter that keeps weight the same
* "Use the same values" as the last time you did the exercise feature
* GitHub action to check for workout log PR and auto-address the notes via AI agent
